### PR TITLE
fix: values in MapProxy.array are binary indicator for sea instead of RGBA

### DIFF
--- a/src/vendeeglobe/engine.py
+++ b/src/vendeeglobe/engine.py
@@ -78,7 +78,7 @@ class Engine:
         print(f"done [{time.time() - t0:.2f} s]")
 
         self.map = Map()
-        self.map_proxy = MapProxy(self.map.array, self.map.dlat, self.map.dlon)
+        self.map_proxy = MapProxy(self.map.sea_array, self.map.dlat, self.map.dlon)
         self.weather = Weather(seed=seed, time_limit=self.time_limit)
         self.graphics = Graphics(
             game_map=self.map, weather=self.weather, players=self.players


### PR DESCRIPTION
Maybe I just miss something, in that case please ignore.
In my understanding the array field of MapProxy should have values of 1 for sea and 0 for land.
Instead I see four-dimensional 8bit values, if not mistaken it's the RGBA code of the pixel representing that part of the globe.