### PR TITLE
ISSUE-18: Fix animations on Gnome

### DIFF
--- a/run/play.py
+++ b/run/play.py
@@ -3,6 +3,10 @@
 import importlib
 import glob
 
+import os
+# Enforces the use of wayland, even on Gnome systems. Which is needed by opengl.
+os.environ["QT_QPA_PLATFORM"] = "wayland"
+
 import vendeeglobe as vg
 
 


### PR DESCRIPTION
Fixes [issue 18](https://github.com/europybots2024/vendeeglobe/issues/18) on Gnome, as is the case on Ubuntu 22.04, by enforcing the use of wayland.

Note that I only tested this fix on my system.