### PR TITLE
ISSUE-18: Fix animations on Gnome, e.g. in Ubuntu 22.04

### DIFF
--- a/run/play.py
+++ b/run/play.py
@@ -3,6 +3,10 @@
 import importlib
 import glob
 
+import os
+# Enforces the use of wayland, even on Gnome systems. Which is needed by opengl
+os.environ["QT_QPA_PLATFORM"] = "wayland"
+
 import vendeeglobe as vg
 
 


### PR DESCRIPTION
Fixes [issue 18](https://github.com/europybots2024/vendeeglobe/issues/18) where animations on Gnome systems. Only tested on Ubuntu 22.04 with python3.11